### PR TITLE
Update _inference.py

### DIFF
--- a/src/sars/_inference.py
+++ b/src/sars/_inference.py
@@ -185,7 +185,10 @@ def sar_multi(
     for name in model_names:
         if name not in _MODEL_REGISTRY:
             raise ValueError(f"Unknown model: {name!r}")
-        fit = _fit_nls(name, data)
+        try:
+            fit = _fit_nls(name, data)
+        except ValueError:
+            continue
         if fit.converged:
             fits.append(fit)
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Skip models that raise a ValueError during non-linear fitting instead of failing the entire multi-model inference.